### PR TITLE
Добавлена поддержка httpOnly Cookie в JwtAuthGuard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "bull-board": "^1.7.2",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "helmet": "^8.0.0",
@@ -6429,6 +6430,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bull-board": "^1.7.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "helmet": "^8.0.0",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,5 +1,6 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, Res } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
+import { Response } from 'express';
 import { UserRole } from 'src/enum/user-role.enum';
 import { AuthService } from './auth.service';
 
@@ -8,7 +9,7 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('register')
-  @Throttle({ default: { limit: 5, ttl: 60000 } }) // ✅ 5 попыток за 60 секунд
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   async register(
     @Body() body: { username: string; password: string; role?: string },
   ) {
@@ -20,25 +21,38 @@ export class AuthController {
   }
 
   @Post('login')
-  @Throttle({ default: { limit: 5, ttl: 60000 } }) // ✅ 5 попыток за 60 секунд
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   async login(
     @Body() body: { username: string; password: string; rememberMe?: boolean },
+    @Res() res: Response,
   ) {
-    return this.authService.login(
+    const { access_token, refresh_token } = await this.authService.login(
       body.username,
       body.password,
       body.rememberMe ?? false,
     );
+
+    res.cookie('accessToken', access_token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 60 * 60 * 1000,
+    });
+
+    return res.send({ refresh_token });
   }
 
   @Post('refresh')
-  @Throttle({ default: { limit: 5, ttl: 60000 } }) // ✅ 5 попыток за 60 секунд
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   async refresh(@Body() body: { refreshToken: string }) {
     return this.authService.refreshToken(body.refreshToken);
   }
 
   @Post('logout')
-  async logout(@Body() body: { userId: string }) {
-    return this.authService.logout(body.userId);
+  async logout(@Body() body: { userId: string }, @Res() res: Response) {
+    await this.authService.logout(body.userId);
+
+    res.clearCookie('accessToken');
+    return res.send({ message: 'User logged out successfully' });
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,7 +3,7 @@ import { JwtService } from '@nestjs/jwt';
 import { InjectModel } from '@nestjs/mongoose';
 import * as bcrypt from 'bcrypt';
 import { Model } from 'mongoose';
-import { UserRole } from '../enums/user-role.enum';
+import { UserRole } from '../enum/user-role.enum';
 import { User, UserDocument } from './schemas/user.schema';
 
 @Injectable()

--- a/src/auth/jwt-auth.guard.ts
+++ b/src/auth/jwt-auth.guard.ts
@@ -1,13 +1,16 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
 
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
   constructor(private jwtService: JwtService) {}
 
   canActivate(context: ExecutionContext): boolean {
-    const request = context.switchToHttp().getRequest();
+    const request = context.switchToHttp().getRequest<Request>();
     const authHeader = request.headers.authorization;
+    const cookieToken = request.cookies?.accessToken;
+
     const allowedRoutes = ['/auth/login', '/auth/register', '/auth/refresh'];
 
     if (allowedRoutes.includes(request.url)) {
@@ -15,19 +18,24 @@ export class JwtAuthGuard implements CanActivate {
       return true;
     }
 
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      console.error('Нет заголовка Authorization');
-      return false;
+    let token: string | undefined;
+    if (authHeader?.startsWith('Bearer ')) {
+      token = authHeader.split(' ')[1];
+    } else if (cookieToken) {
+      token = cookieToken;
     }
 
-    const token = authHeader.split(' ')[1];
+    if (!token) {
+      console.error('Нет токена в Authorization или Cookies');
+      return false;
+    }
 
     try {
       const decoded = this.jwtService.verify(token, {
         secret: process.env.JWT_SECRET,
       });
 
-      if (!decoded || !decoded.sub || !decoded.role) {
+      if (!decoded?.sub || !decoded?.role) {
         console.error('Токен не содержит sub или role:', decoded);
         return false;
       }
@@ -38,6 +46,7 @@ export class JwtAuthGuard implements CanActivate {
         role: decoded.role,
       };
 
+      console.log('Успешная валидация JWT');
       return true;
     } catch (err) {
       console.error('Ошибка валидации JWT:', err.message);

--- a/src/auth/schemas/user.schema.ts
+++ b/src/auth/schemas/user.schema.ts
@@ -1,6 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
-import { UserRole } from '../../enums/user-role.enum';
+import { UserRole } from '../../enum/user-role.enum';
 
 export type UserDocument = User & Document;
 

--- a/src/enums/user-role.enum.ts
+++ b/src/enums/user-role.enum.ts
@@ -1,4 +1,0 @@
-export enum UserRole {
-  ADMIN = 'admin',
-  USER = 'user',
-}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,17 @@
 import { NestFactory } from '@nestjs/core';
+import * as cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.use(cookieParser());
+
+  app.enableCors({
+    origin: 'http://localhost:3000',
+    credentials: true,
+  });
+
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();


### PR DESCRIPTION
- Теперь accessToken хранится в httpOnly Cookie
- JwtAuthGuard проверяет и `Authorization`, и Cookies
- Улучшены логи ошибок
